### PR TITLE
Add dummy pa_channel_map_init_extend to allow steam remote play

### DIFF
--- a/src/fakepulse.c
+++ b/src/fakepulse.c
@@ -16,7 +16,6 @@ FAKE(pa_channel_map_equal);
 FAKE(pa_channel_map_has_position);
 FAKE(pa_channel_map_init);
 FAKE(pa_channel_map_init_auto);
-FAKE(pa_channel_map_init_extend);
 FAKE(pa_channel_map_init_mono);
 FAKE(pa_channel_map_init_stereo);
 FAKE(pa_channel_map_mask);
@@ -459,4 +458,7 @@ int pa_context_errno(const void* c) {
 
 void pa_threaded_mainloop_unlock (void* mainloop) {
   // do nothing
+}
+void* pa_channel_map_init_extend (void* channel_map, unsigned channels, int def){
+    return NULL;
 }


### PR DESCRIPTION
This dummy patch allows to use steam with remote play.
Drawback:
- no sound on the remote (didn't check on the host if it still work)
- before launching the game, there is nothing except the controller on the remote screen (tested with a smartphone)
- the game launch on the remote screen, but unfortunately the controller on the remote screen(a phone) does not work ingame, but it work in big picture mode menu (still no images of big picture mode on the remote screen)