### PR TITLE
Updated Makefile to reflect package change of linux_libusb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ DEPS = ruby                      \
        ca_root_nss               \
        gtar                      \
        liberation-fonts-ttf      \
-       linux_libusb              \
+       linux_libusb-c7           \
        linux-c7-alsa-plugins-oss \
        linux-c7-dbus-libs        \
        linux-c7-devtools         \


### PR DESCRIPTION
It appears the FreeBSD package has changed from linux_libusb to linux_libusb-c7

----
Before:

root@cuddles:/tmp/linuxulator-steam-utils # make dependencies
pkg install -r FreeBSD ruby                       ca_root_nss                gtar                       liberation-fonts-ttf       linux_libusb               linux-c7-alsa-plugins-oss  linux-c7-dbus-libs         linux-c7-devtools          linux-c7-dri               linux-c7-gtk2              linux-c7-nss               zenity 
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
pkg: No packages available to install matching 'linux_libusb' have been found in the repositories
*** Error code 1

Stop.
make: stopped making "dependencies" in /tmp/linuxulator-steam-utils


After

root@cuddles:/tmp/linuxulator-steam-utils # make dependencies
pkg install -r FreeBSD ruby                       ca_root_nss                gtar                       liberation-fonts-ttf       linux_libusb-c7		  linux-c7-alsa-plugins-oss  linux-c7-dbus-libs         linux-c7-devtools          linux-c7-dri               linux-c7-gtk2              linux-c7-nss               zenity 
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
