### PR TITLE
Add linux-nvidia-libs-580 to the Makefile NVIDIA_DEPS list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ NVIDIA_DEPS != \
 	  340) echo linux-nvidia-libs-340;; \
 	  390) echo linux-nvidia-libs-390;; \
 	  470) echo linux-nvidia-libs-470;; \
+	  580) echo linux-nvidia-libs-580;; \
 	  *)   echo linux-nvidia-libs;;     \
 	esac
 


### PR DESCRIPTION
Added support for the new version 580 NVIDIA ports to the Makefile. See the new linux-nvidia-libs port [here](https://www.freshports.org/x11/linux-nvidia-libs-580/).

I was able to successfully install and use Steam with this change on my system running the following NVIDIA module version:
`hw.nvidia.version: NVIDIA UNIX x86_64 Kernel Module  580.173.02  Tue Jun 23 08:38:17 UTC 2026`